### PR TITLE
modularization #70

### DIFF
--- a/input/ch.fhir.ig.ch-orf.xml
+++ b/input/ch.fhir.ig.ch-orf.xml
@@ -345,6 +345,14 @@
 
     <resource>
       <reference>
+        <reference value="Questionnaire/ch-orf-module-practitioner-nametel"/>
+      </reference>
+      <name value="ModuleQuestionnairePractitionerNameTel"/>
+      <description value="Module Questionnaire Practitioner with name and telecom"/>
+    </resource>
+
+    <resource>
+      <reference>
         <reference value="QuestionnaireResponse/qr-order-referral-form"/>
       </reference>
       <name value="QuestionnaireResponse Order-Referral-Form"/>

--- a/input/ch.fhir.ig.ch-orf.xml
+++ b/input/ch.fhir.ig.ch-orf.xml
@@ -37,7 +37,8 @@
   <dependsOn id="chcore">
     <uri value="http://fhir.ch/ig/ch-core/ImplementationGuide/ch.fhir.ig.ch-core"/>
     <packageId value="ch.fhir.ig.ch-core"/>
-    <version value="current"/> <!--TBD: 2.1.0 -->
+    <version value="current"/>
+    <!--TBD: 2.1.0 -->
   </dependsOn>
   <dependsOn id="sdc">
     <uri value="http://hl7.org/fhir/uv/sdc/ImplementationGuide/hl7.fhir.uv.sdc"/>
@@ -267,6 +268,79 @@
       <name value="Questionnaire Order-Referral-Form"/>
       <description value="Example for Questionnaire"/>
       <exampleCanonical value="http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-questionnaire"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/order-referral-form-modular"/>
+      </reference>
+      <name value="Questionnaire Order-Referral-Form (Modular version)"/>
+      <description value="Example for Questionnaire (Modular version)"/>
+      <exampleCanonical value="http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-questionnaire"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-order"/>
+      </reference>
+      <name value="Module Questionnaire order"/>
+      <description value="Subquestionnaire order"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-receiver"/>
+      </reference>
+      <name value="Module Questionnaire receiver"/>
+      <description value="Subquestionnaire receiver"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-patient"/>
+      </reference>
+      <name value="Module Questionnaire patient"/>
+      <description value="Subquestionnaire patient"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-requestedencounter"/>
+      </reference>
+      <name value="Module Questionnaire requestedEncounter"/>
+      <description value="Subquestionnaire requestedEncounter"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-coverage"/>
+      </reference>
+      <name value="Module Questionnaire Coverage"/>
+      <description value="Subquestionnaire Coverage"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-sender"/>
+      </reference>
+      <name value="Module Questionnaire Sender"/>
+      <description value="Subquestionnaire Sender"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-receivercopy"/>
+      </reference>
+      <name value="Module Questionnaire receiverCopy"/>
+      <description value="Subquestionnaire receiverCopy"/>
+    </resource>
+
+    <resource>
+      <reference>
+        <reference value="Questionnaire/ch-orf-module-appointment"/>
+      </reference>
+      <name value="Module Questionnaire Appointment"/>
+      <description value="Subquestionnaire Appointment"/>
     </resource>
 
     <resource>

--- a/input/ch.fhir.ig.ch-orf.xml
+++ b/input/ch.fhir.ig.ch-orf.xml
@@ -281,6 +281,14 @@
 
     <resource>
       <reference>
+        <reference value="Questionnaire/ch-orf-module-address"/>
+      </reference>
+      <name value="Module Questionnaire address"/>
+      <description value="Subquestionnaire address"/>
+    </resource>
+
+    <resource>
+      <reference>
         <reference value="Questionnaire/ch-orf-module-order"/>
       </reference>
       <name value="Module Questionnaire order"/>

--- a/input/fsh/EX_Questionnaire.fsh
+++ b/input/fsh/EX_Questionnaire.fsh
@@ -1,912 +1,757 @@
 Instance: order-referral-form
-InstanceOf: ChOrfQuestionnaire
-Title: "Questionnaire Order-Referral-Form"
-Description: "Example for Questionnaire"
-* meta.profile[+] = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-questionnaire"
+InstanceOf: Questionnaire
+Usage: #example
+* meta.profile[0] = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-questionnaire"
 * meta.profile[+] = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire"
 * meta.profile[+] = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-extr-smap"
 * meta.profile[+] = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-pop-exp"
-
-
 * extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-targetStructureMap"
-* extension[0].valueCanonical = "http://fhir.ch/ig/ch-orf/StructureMap/OrfQrToBundle"
-
-* extension[1].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-sourceStructureMap"
-* extension[1].valueCanonical = "http://fhir.ch/ig/ch-orf/StructureMap/OrfPrepopBundleToQr"
-
-* extension[2].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext"
-* extension[2].extension[0].url = "name"
-* extension[2].extension[0].valueId = "Bundle"
-* extension[2].extension[1].url = "type"
-* extension[2].extension[1].valueCode = #Bundle
-* extension[2].extension[2].url = "description"
-* extension[2].extension[2].valueString = "The Bundle that is to be used to pre-populate the form"
-
-* url = "http://fhir.ch/ig/ch-orf/Questionnaire/order-referral-form"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/StructureMap/OrfQrToBundle"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-sourceStructureMap"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/StructureMap/OrfPrepopBundleToQr"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext"
+* extension[=].extension[0].url = "name"
+* extension[=].extension[=].valueId = "Bundle"
+* extension[=].extension[+].url = "type"
+* extension[=].extension[=].valueCode = #Bundle
+* extension[=].extension[+].url = "description"
+* extension[=].extension[=].valueString = "The Bundle that is to be used to pre-populate the form"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-order|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receiver|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-patient|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-requestedencounter|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-coverage|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-sender|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receivercopy|1.1.0"
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembledFrom"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-appointment|1.1.0"
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/order-referral-form-modular"
+* version = "1.1.0-assembled"
 * name = "OrderReferralForm"
 * title = "Order-Referral-Form"
 * status = #active
 * subjectType = #Patient
-* date = "2022-01-06"
+* date = "2022-05-04"
 * publisher = "HL7 Switzerland"
-
-// ---------- order (Auftrag) ----------
-* item[+].linkId = "order"
-* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-document#Bundle"
+* contact.name = "HL7 Switzerland"
+* contact.telecom.system = #url
+* contact.telecom.value = "https://www.hl7.ch/"
+* jurisdiction = urn:iso:std:iso:3166#CH
+* copyright = "CC-BY-SA-4.0"
+* item[0].linkId = "order"
 * item[=].text = "Auftrag"
 * item[=].type = #group
 * item[=].required = true
-
-* item[=].item[+].linkId = "order.placerOrderIdentifier"
+* item[=].item[0].linkId = "order.placerOrderIdentifier"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:placerOrderIdentifier.value"
 * item[=].item[=].text = "Auftragsnummer des Auftraggebers"
 * item[=].item[=].type = #string
-
 * item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
 * item[=].item[=].extension.valueBoolean = true
 * item[=].item[=].linkId = "order.placerOrderIdentifierDomain"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:placerOrderIdentifier.system"
 * item[=].item[=].text = "Identifier Domain der Auftragsnummer des Auftraggebers"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "order.fillerOrderIdentifier"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:fillerOrderIdentifier.value"
 * item[=].item[=].text = "Auftragsnummer des Auftragsempfängers"
 * item[=].item[=].type = #string
-
 * item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
 * item[=].item[=].extension.valueBoolean = true
 * item[=].item[=].linkId = "order.fillerOrderIdentifierDomain"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:fillerOrderIdentifier.system"
 * item[=].item[=].text = "Identifier Domain der Auftragsnummer des Auftragsempfängers"
 * item[=].item[=].type = #string
-
 * item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
 * item[=].item[=].extension.valueBoolean = true
 * item[=].item[=].linkId = "order.precedentDocumentIdentifier"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:precedentDocument"
 * item[=].item[=].text = "Identifier des Vorgängerdokuments"
 * item[=].item[=].type = #string
-
-// ---------- Urgent Notification Contact for this document ----------
 * item[=].item[+].linkId = "order.notificationContactDocument"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:urgentNoficationContactForThisDocument"
 * item[=].item[=].text = "Dringender Benachrichtigungskontakt für dieses Dokument"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
-* item[=].item[=].item[=].text = "Zu benachrichtigende Person"
-* item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.title"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
-* item[=].item[=].item[=].item[=].text = "Titel"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.familyName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
-* item[=].item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.givenName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
-* item[=].item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.phone"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.email"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].item[=].type = #string
-
-// ---------- Urgent Notification Contact for the Response to this document ----------
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item.extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item.extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item.extension.valueExpression.expression = "'order.notificationContactDocument.practitioner.'"
+* item[=].item[=].item.linkId = "order.notificationContactDocument.practitioner"
+* item[=].item[=].item.definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].item.text = "Zu benachrichtigende Person"
+* item[=].item[=].item.type = #group
+* item[=].item[=].item.item[0].linkId = "order.notificationContactDocument.practitioner.title"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].item.item[=].text = "Titel"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocument.practitioner.familyName"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item.item[=].text = "Name"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocument.practitioner.givenName"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item.item[=].text = "Vorname"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocument.practitioner.phone"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item.item[=].text = "Telefon"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocument.practitioner.email"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item.item[=].text = "E-Mail"
+* item[=].item[=].item.item[=].type = #string
 * item[=].item[+].linkId = "order.notificationContactDocumentResponse"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:urgentNoficationContactForTheResponseToThisDocument"
 * item[=].item[=].text = "Dringender Benachrichtigungskontakt für die Antwort auf dieses Dokument"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
-* item[=].item[=].item[=].text = "Zu benachrichtigende Person"
-* item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.title"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
-* item[=].item[=].item[=].item[=].text = "Titel"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.familyName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
-* item[=].item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.givenName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
-* item[=].item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.phone"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.email"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].item[=].type = #string
-
-// ---------- Order Priority ----------
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item.extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item.extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item.extension.valueExpression.expression = "'order.notificationContactDocumentResponse.practitioner.'"
+* item[=].item[=].item.linkId = "order.notificationContactDocumentResponse.practitioner"
+* item[=].item[=].item.definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].item.text = "Zu benachrichtigende Person"
+* item[=].item[=].item.type = #group
+* item[=].item[=].item.item[0].linkId = "order.notificationContactDocumentResponse.practitioner.title"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].item.item[=].text = "Titel"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocumentResponse.practitioner.familyName"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item.item[=].text = "Name"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocumentResponse.practitioner.givenName"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item.item[=].text = "Vorname"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocumentResponse.practitioner.phone"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item.item[=].text = "Telefon"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "order.notificationContactDocumentResponse.practitioner.email"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item.item[=].text = "E-Mail"
+* item[=].item[=].item.item[=].type = #string
 * item[=].item[+].linkId = "order.priority"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.priority"
 * item[=].item[=].text = "Auftragspriorität"
 * item[=].item[=].type = #choice
-* item[=].item[=].answerOption[+].valueCoding = RequestPriority#routine "Die Anfrage hat normale Priorität."
+* item[=].item[=].answerOption[0].valueCoding = http://hl7.org/fhir/request-priority#routine "Die Anfrage hat normale Priorität."
 * item[=].item[=].answerOption[=].initialSelected = true
-* item[=].item[=].answerOption[+].valueCoding = RequestPriority#urgent "Die Anfrage sollte dringend bearbeitet werden - höhere Priorität als normal."
-* item[=].item[=].answerOption[+].valueCoding = RequestPriority#asap "Die Anfrage sollte so schnell wie möglich bearbeitet werden - höhere Priorität als dringend."
-* item[=].item[=].answerOption[+].valueCoding = RequestPriority#stat "Die Anfrage sollte sofort bearbeitet werden - höchstmögliche Priorität. Z.B. bei einem Notfall."
-
-// ---------- Receiver: Person/organization who receives the document ----------
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/request-priority#urgent "Die Anfrage sollte dringend bearbeitet werden - höhere Priorität als normal."
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/request-priority#asap "Die Anfrage sollte so schnell wie möglich bearbeitet werden - höhere Priorität als dringend."
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/request-priority#stat "Die Anfrage sollte sofort bearbeitet werden - höchstmögliche Priorität. Z.B. bei einem Notfall."
 * item[+].linkId = "receiver"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:receiver"
 * item[=].text = "Empfänger"
 * item[=].type = #group
-
-* item[=].item[+].linkId = "receiver.practitioner"
+* item[=].item[0].linkId = "receiver.practitioner"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
 * item[=].item[=].text = "Empfangende Person"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "receiver.practitioner.title"
+* item[=].item[=].item[0].linkId = "receiver.practitioner.title"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
 * item[=].item[=].item[=].text = "Titel"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.practitioner.familyName"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
 * item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.practitioner.givenName"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
 * item[=].item[=].item[=].text = "Vorname"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.practitioner.gln"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:GLN.value"
 * item[=].item[=].item[=].text = "GLN"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.practitioner.zsr"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:ZSR.value"
 * item[=].item[=].item[=].text = "ZSR"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.practitioner.phone"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.practitioner.email"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "receiver.organization"
+* item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'receiver.organization.'"
+* item[=].item[=].linkId = "receiver.organization"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
 * item[=].item[=].text = "Empfangende Organisation"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "receiver.organization.name"
+* item[=].item[=].item[0].linkId = "receiver.organization.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
 * item[=].item[=].item[=].text = "Name der Organisation"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.organization.gln"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.identifier:GLN"
 * item[=].item[=].item[=].text = "GLN"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.organization.streetAddressLine"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.line"
 * item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[+].linkId = "receiver.organization.postalCode"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.postalCode"
 * item[=].item[=].item[=].text = "PLZ"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.organization.city"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.city"
 * item[=].item[=].item[=].text = "Ort"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiver.organization.country"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.country"
 * item[=].item[=].item[=].text = "Land"
 * item[=].item[=].item[=].type = #string
-
-// ---------- Patient: The principle target of a particular Form Content is one patient ----------
 * item[+].linkId = "patient"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.subject"
 * item[=].text = "Patient"
 * item[=].type = #group
 * item[=].required = true
-
-* item[=].item[+].linkId = "patient.familyName"
+* item[=].item[0].linkId = "patient.familyName"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.family"
 * item[=].item[=].text = "Name"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.maidenName"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.family"
 * item[=].item[=].text = "Ledigname"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.givenName"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.given"
 * item[=].item[=].text = "Vorname"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.localPid"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:LocalPid.value"
 * item[=].item[=].text = "Lokale Patienten-ID"
 * item[=].item[=].type = #string
-
 * item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
 * item[=].item[=].extension.valueBoolean = true
 * item[=].item[=].linkId = "patient.localPidDomain"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:LocalPid.system"
 * item[=].item[=].text = "Lokale Patienten-ID Domain"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.birthDate"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.birthDate"
 * item[=].item[=].text = "Geburtsdatum"
 * item[=].item[=].type = #date
-
 * item[=].item[+].linkId = "patient.gender"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.gender"
 * item[=].item[=].text = "Geschlecht"
 * item[=].item[=].type = #choice
-* item[=].item[=].answerOption[+].valueCoding = AdministrativeGender#male "Männlich"
+* item[=].item[=].answerOption[0].valueCoding = http://hl7.org/fhir/administrative-gender#male "Männlich"
 * item[=].item[=].answerOption[=].initialSelected = true
-* item[=].item[=].answerOption[+].valueCoding = AdministrativeGender#female "Weiblich"
-* item[=].item[=].answerOption[+].valueCoding = AdministrativeGender#other "Anderes"
-
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/administrative-gender#female "Weiblich"
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/administrative-gender#other "Anderes"
 * item[=].item[+].linkId = "patient.maritalStatus"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.maritalStatus"
 * item[=].item[=].text = "Zivilstand"
 * item[=].item[=].type = #choice
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#1 "ledig"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#2 "verheiratet"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#3 "verwitwet"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#4 "geschieden"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#5 "unverheiratet"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#6 "in eingetragener Partnerschaft"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#7 "aufgelöste Partnerschaft"
-* item[=].item[=].answerOption[+].valueCoding = EchMaritalStatus#9 "unbekannt"
-
+* item[=].item[=].answerOption[0].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#1 "ledig"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#2 "verheiratet"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#3 "verwitwet"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#4 "geschieden"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#5 "unverheiratet"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#6 "in eingetragener Partnerschaft"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#7 "aufgelöste Partnerschaft"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/ech-11-maritalstatus#9 "unbekannt"
 * item[=].item[+].linkId = "patient.phone"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.telecom.value"
 * item[=].item[=].text = "Telefon"
 * item[=].item[=].type = #string
 * item[=].item[=].repeats = true
-
 * item[=].item[+].linkId = "patient.email"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.telecom.value"
 * item[=].item[=].text = "E-Mail"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.streetAddressLine"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.line"
 * item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].type = #string
 * item[=].item[=].repeats = true
-
 * item[=].item[+].linkId = "patient.postalCode"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.postalCode"
 * item[=].item[=].text = "PLZ"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.city"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.city"
 * item[=].item[=].text = "Ort"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.country"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.country"
 * item[=].item[=].text = "Land"
 * item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "patient.languageOfCorrespondance"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.communication:languageOfCorrespondance"
 * item[=].item[=].text = "Korrespondenssprache"
 * item[=].item[=].type = #choice
 * item[=].item[=].answerValueSet = "http://fhir.ch/ig/ch-epr-term/ValueSet/DocumentEntry.languageCode"
-
-// ---------- Patient Contact Person : The principle target of a particular Form Content is one patient ----------
 * item[=].item[+].linkId = "patient.contactperson"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact"
 * item[=].item[=].text = "Kontaktperson"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "patient.contactperson.relationship"
+* item[=].item[=].item[0].linkId = "patient.contactperson.relationship"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.relationship.text"
 * item[=].item[=].item[=].text = "Beziehung"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "patient.contactperson.familyName"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.name.family"
 * item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "patient.contactperson.givenName"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.name.given"
 * item[=].item[=].item[=].text = "Vorname"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "patient.contactperson.phone"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.telecom.value"
 * item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[+].linkId = "patient.contactperson.email"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.telecom.value"
 * item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].type = #string
-
-// ---------- Encounter Class (Ambulant / Satinär / Notfall) ----------
 * item[+].linkId = "requestedEncounter"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.extension:requestedEncounterDetails"
 * item[=].text = "Patientenaufnahme"
 * item[=].type = #group
-
-* item[=].item[+].linkId = "requestedEncounter.class"
+* item[=].item[0].linkId = "requestedEncounter.class"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-encounter#Encounter.class"
-* item[=].item[=].type = #choice
 * item[=].item[=].text = "Voraussichtlich: Ambulant / Stationär / Notfall"
-* item[=].item[=].answerOption[+].valueCoding = V3ActCode#AMB "Ambulant"
-* item[=].item[=].answerOption[+].valueCoding = V3ActCode#IMP "Stationär"
-* item[=].item[=].answerOption[+].valueCoding = V3ActCode#EMER "Notfall"
-
+* item[=].item[=].type = #choice
+* item[=].item[=].answerOption[0].valueCoding = http://terminology.hl7.org/CodeSystem/v3-ActCode#AMB "Ambulant"
+* item[=].item[=].answerOption[+].valueCoding = http://terminology.hl7.org/CodeSystem/v3-ActCode#IMP "Stationär"
+* item[=].item[=].answerOption[+].valueCoding = http://terminology.hl7.org/CodeSystem/v3-ActCode#EMER "Notfall"
 * item[=].item[+].linkId = "requestedEncounter.desiredAccommodation"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-encounter#Encounter.extension:desiredAccommodation"
 * item[=].item[=].text = "Zimmerkategorie"
 * item[=].item[=].type = #choice
-* item[=].item[=].answerOption[+].valueCoding = ChCoreCSEncounterType#1 "allgemein"
-* item[=].item[=].answerOption[+].valueCoding = ChCoreCSEncounterType#2 "halbprivat"
-* item[=].item[=].answerOption[+].valueCoding = ChCoreCSEncounterType#3 "privat"
-
-
-// ---------- Coverage (Kostenträger) ----------
-// Design as agreed with eHealth Suisse and Cistec 09.06.2021
-
+* item[=].item[=].answerOption[0].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/bfs-medstats-21-encountertype#1 "allgemein"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/bfs-medstats-21-encountertype#2 "halbprivat"
+* item[=].item[=].answerOption[+].valueCoding = http://fhir.ch/ig/ch-core/CodeSystem/bfs-medstats-21-encountertype#3 "privat"
 * item[+].linkId = "coverage"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.insurance"
 * item[=].text = "Kostenträger"
 * item[=].type = #group
-
-* item[=].item[+].linkId = "coverage.beneficiary"
+* item[=].item[0].linkId = "coverage.beneficiary"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.beneficiary"
 * item[=].item[=].text = "Begünstigter (Patient)"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.beneficiary.ahvn13"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:AHVN13"
-* item[=].item[=].item[=].text = "AHV-Nr. des Patienten"
-* item[=].item[=].item[=].type = #string
-
-// KVG
+* item[=].item[=].item.linkId = "coverage.beneficiary.ahvn13"
+* item[=].item[=].item.definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:AHVN13"
+* item[=].item[=].item.text = "AHV-Nr. des Patienten"
+* item[=].item[=].item.type = #string
 * item[=].item[+].linkId = "coverage.kvg"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Krankenkasse (nach KVG)"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.kvg.name"
+* item[=].item[=].item[0].linkId = "coverage.kvg.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
 * item[=].item[=].item[=].text = "Name der Versicherung"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "coverage.kvg.insuranceCardNumber"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
 * item[=].item[=].item[=].text = "Kennnummer der Versichertenkarte"
 * item[=].item[=].item[=].type = #string
-
-// UVG
 * item[=].item[+].linkId = "coverage.uvg"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Unfallversicherung (nach UVG)"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.uvg.name"
+* item[=].item[=].item[0].linkId = "coverage.uvg.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
 * item[=].item[=].item[=].text = "Name der Versicherung"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "coverage.uvg.claimNumber"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
 * item[=].item[=].item[=].text = "Schadennummer"
 * item[=].item[=].item[=].type = #string
-
-// Zusatz
 * item[=].item[+].linkId = "coverage.vvg"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Zusatzversicherung (nach VVG)"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.vvg.name"
+* item[=].item[=].item[0].linkId = "coverage.vvg.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
 * item[=].item[=].item[=].text = "Name der Versicherung"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "coverage.vvg.insuranceCardNumber"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
 * item[=].item[=].item[=].text = "Kennnummer der Versichertenkarte"
 * item[=].item[=].item[=].type = #string
-
-// IV
 * item[=].item[+].linkId = "coverage.iv"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Invalidenversicherung (IV)"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.iv.verfuegungsnummer"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
-* item[=].item[=].item[=].text = "IV-Verfügungsnummer"
-* item[=].item[=].item[=].type = #string
-
-// MV
+* item[=].item[=].item.linkId = "coverage.iv.verfuegungsnummer"
+* item[=].item[=].item.definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].item.text = "IV-Verfügungsnummer"
+* item[=].item[=].item.type = #string
 * item[=].item[+].linkId = "coverage.mv"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Militärversicherung (MV)"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.mv.versichertennummer"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
-* item[=].item[=].item[=].text = "MV-Versichertennummer"
-* item[=].item[=].item[=].type = #string
-
-// Self
+* item[=].item[=].item.linkId = "coverage.mv.versichertennummer"
+* item[=].item[=].item.definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].item.text = "MV-Versichertennummer"
+* item[=].item[=].item.type = #string
 * item[=].item[+].linkId = "coverage.self"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Selbstzahler"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.self.patient"
+* item[=].item[=].item[0].linkId = "coverage.self.patient"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
 * item[=].item[=].item[=].text = "Patient selbst"
 * item[=].item[=].item[=].type = #boolean
-
 * item[=].item[=].item[+].linkId = "coverage.self.patientRelatedPerson"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
 * item[=].item[=].item[=].text = "Andere Person"
 * item[=].item[=].item[=].type = #boolean
-* item[=].item[=].item[=].enableWhen[+].question = "coverage.self.patient"
-* item[=].item[=].item[=].enableWhen[=].operator = #=
-* item[=].item[=].item[=].enableWhen[=].answerBoolean = false
-
-* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson" 
+* item[=].item[=].item[=].enableWhen.question = "coverage.self.patient"
+* item[=].item[=].item[=].enableWhen.operator = #=
+* item[=].item[=].item[=].enableWhen.answerBoolean = false
+* item[=].item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item[=].extension.valueExpression.expression = "'coverage.self.relatedPerson.'"
+* item[=].item[=].item[=].linkId = "coverage.self.relatedPerson"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
-* item[=].item[=].item[=].text = "Andere Person"   
+* item[=].item[=].item[=].text = "Andere Person"
 * item[=].item[=].item[=].type = #group
-* item[=].item[=].item[=].enableWhen[+].question = "coverage.self.patientRelatedPerson"
-* item[=].item[=].item[=].enableWhen[=].operator = #=
-* item[=].item[=].item[=].enableWhen[=].answerBoolean = true
-
-* item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.familyName"
+* item[=].item[=].item[=].enableWhen.question = "coverage.self.patientRelatedPerson"
+* item[=].item[=].item[=].enableWhen.operator = #=
+* item[=].item[=].item[=].enableWhen.answerBoolean = true
+* item[=].item[=].item[=].item[0].linkId = "coverage.self.relatedPerson.familyName"
 * item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.family"
 * item[=].item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.givenName"
 * item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.given"
 * item[=].item[=].item[=].item[=].text = "Vorname"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.phone"
 * item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
 * item[=].item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.email"
 * item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
 * item[=].item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.streetAddressLine"
-* item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.line"
 * item[=].item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.postalCode"
-* item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.postalCode"
 * item[=].item[=].item[=].item[=].text = "PLZ"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.city"
-* item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.city"
 * item[=].item[=].item[=].item[=].text = "Ort"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.country"
-* item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.country"
 * item[=].item[=].item[=].item[=].text = "Land"
 * item[=].item[=].item[=].item[=].type = #string
-
-
-// Other
 * item[=].item[+].linkId = "coverage.other"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
 * item[=].item[=].text = "Anderer Kostenträger"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "coverage.other.name"
+* item[=].item[=].item[0].linkId = "coverage.other.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
 * item[=].item[=].item[=].text = "Name des Kostenträgers"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "coverage.other.id"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
 * item[=].item[=].item[=].text = "Beliebige ID"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "coverage.other.id.note"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier.type.text"
 * item[=].item[=].item[=].text = "Bemerkung zur ID"
 * item[=].item[=].item[=].type = #string
-
-// The situation where a person and not a organization is an other payer is not depicted. 
-// Id's of insurances other than kvg are proprietary. Zusatzversicherung however may use the Kennnummer der Versichertenkarte (KVG).
-// Id's for other are not defined.
-
-// ---------- sender (Absender) ----------
 * item[+].linkId = "sender"
 * item[=].text = "Absender"
 * item[=].type = #group
 * item[=].required = true
-
-// ---------- Author: The person/organization responsible for Form Content ----------
-* item[=].item[+].linkId = "sender.author"
+* item[=].item[0].linkId = "sender.author"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.author"
 * item[=].item[=].text = "Verantwortlicher"
 * item[=].item[=].type = #group
 * item[=].item[=].required = true
-
-* item[=].item[=].item[+].linkId = "sender.author.practitioner"
+* item[=].item[=].item[0].linkId = "sender.author.practitioner"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
 * item[=].item[=].item[=].text = "Verantwortliche Person"
 * item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.title"
+* item[=].item[=].item[=].item[0].linkId = "sender.author.practitioner.title"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
 * item[=].item[=].item[=].item[=].text = "Titel"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.familyName"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
 * item[=].item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.givenName"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
 * item[=].item[=].item[=].item[=].text = "Vorname"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.gln"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:GLN.value"
 * item[=].item[=].item[=].item[=].text = "GLN"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.zsr"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:ZSR.value"
 * item[=].item[=].item[=].item[=].text = "ZSR"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.phone"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.practitioner.email"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "sender.author.organization"
+* item[=].item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item[=].extension.valueExpression.expression = "'sender.author.organization.'"
+* item[=].item[=].item[=].linkId = "sender.author.organization"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
 * item[=].item[=].item[=].text = "Verantwortliche Organisation"
 * item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "sender.author.organization.name"
+* item[=].item[=].item[=].item[0].linkId = "sender.author.organization.name"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
 * item[=].item[=].item[=].item[=].text = "Name der Organisation"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.organization.gln"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.identifier:GLN"
 * item[=].item[=].item[=].item[=].text = "GLN"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.organization.streetAddressLine"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.line"
 * item[=].item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.organization.postalCode"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.postalCode"
 * item[=].item[=].item[=].item[=].text = "PLZ"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.organization.city"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.city"
 * item[=].item[=].item[=].item[=].text = "Ort"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "sender.author.organization.country"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.country"
 * item[=].item[=].item[=].item[=].text = "Land"
 * item[=].item[=].item[=].item[=].type = #string
-
-// ---------- Data Entry Person: The person who has typed/filled in the Form Content. ----------
 * item[=].item[+].linkId = "sender.dataenterer"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:dataEnterer"
 * item[=].item[=].text = "Erfasser"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
-* item[=].item[=].item[=].text = "Erfassende Person"
-* item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.familyName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
-* item[=].item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.givenName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
-* item[=].item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.phone"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.email"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].item[=].type = #string
-
-// ---------- Copy Receiver (Copy of this order and all results therefrom) ----------
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item.extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item.extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item.extension.valueExpression.expression = "'sender.dataenterer.practitioner.'"
+* item[=].item[=].item.linkId = "sender.dataenterer.practitioner"
+* item[=].item[=].item.definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].item.text = "Erfassende Person"
+* item[=].item[=].item.type = #group
+* item[=].item[=].item.item[0].linkId = "sender.dataenterer.practitioner.title"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].item.item[=].text = "Titel"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "sender.dataenterer.practitioner.familyName"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item.item[=].text = "Name"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "sender.dataenterer.practitioner.givenName"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item.item[=].text = "Vorname"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "sender.dataenterer.practitioner.phone"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item.item[=].text = "Telefon"
+* item[=].item[=].item.item[=].type = #string
+* item[=].item[=].item.item[+].linkId = "sender.dataenterer.practitioner.email"
+* item[=].item[=].item.item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item.item[=].text = "E-Mail"
+* item[=].item[=].item.item[=].type = #string
 * item[+].linkId = "receiverCopy"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:copyReceiver"
 * item[=].text = "Kopieempfänger (Kopie dieses Auftrags und aller daraus resultierenden Resultate)"
 * item[=].type = #group
-
-* item[=].item[+].linkId = "receiverCopy.practitionerRole"
+* item[=].item[0].linkId = "receiverCopy.practitionerRole"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole"
 * item[=].item[=].text = "Gesundheitsfachperson oder -organisation"
 * item[=].item[=].type = #group
 * item[=].item[=].repeats = true
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner"
+* item[=].item[=].item[0].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item[=].extension.valueExpression.expression = "'receiverCopy.practitionerRole.practitioner.'"
+* item[=].item[=].item[=].linkId = "receiverCopy.practitionerRole.practitioner"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
 * item[=].item[=].item[=].text = "Gesundheitsfachperson"
 * item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.title"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.prefix"
+* item[=].item[=].item[=].item[0].linkId = "receiverCopy.practitionerRole.practitioner.title"
+* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
 * item[=].item[=].item[=].item[=].text = "Titel"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.familyName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.family"
+* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
 * item[=].item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.givenName"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.given"
+* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
 * item[=].item[=].item[=].item[=].text = "Vorname"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.phone"
-* item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/ContactPoint#ContactPoint.value"
+* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.email"
-* item[=].item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/ContactPoint#ContactPoint.value"
+* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization"
+* item[=].item[=].item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item[=].extension.valueExpression.expression = "'receiverCopy.practitionerRole.organization.'"
+* item[=].item[=].item[=].linkId = "receiverCopy.practitionerRole.organization"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
 * item[=].item[=].item[=].text = "Gesundheitsorganisatiton"
 * item[=].item[=].item[=].type = #group
-
-* item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.name"
+* item[=].item[=].item[=].item[0].linkId = "receiverCopy.practitionerRole.organization.name"
 * item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
 * item[=].item[=].item[=].item[=].text = "Name der Organisation"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.streetAddressLine"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.line"
 * item[=].item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.postalCode"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.postalCode"
 * item[=].item[=].item[=].item[=].text = "PLZ"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.city"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.city"
 * item[=].item[=].item[=].item[=].text = "Ort"
 * item[=].item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.country"
-* item[=].item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.country"
 * item[=].item[=].item[=].item[=].text = "Land"
 * item[=].item[=].item[=].item[=].type = #string
-
-
 * item[=].item[+].linkId = "receiverCopy.patient"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient"
 * item[=].item[=].text = "Patient selbst"
 * item[=].item[=].type = #boolean
-
-
 * item[=].item[+].linkId = "receiverCopy.relatedPerson"
 * item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson"
 * item[=].item[=].text = "Andere Person"
 * item[=].item[=].type = #group
 * item[=].item[=].repeats = true
-
-* item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.familyName"
+* item[=].item[=].item[0].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].item[=].extension.valueExpression.expression = "'receiverCopy.relatedPerson.'"
+* item[=].item[=].item[=].linkId = "receiverCopy.relatedPerson.familyName"
 * item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.family"
 * item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.givenName"
 * item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.given"
 * item[=].item[=].item[=].text = "Vorame"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.phone"
 * item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
 * item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.email"
 * item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
 * item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.streetAddressLine"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.line"
 * item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.postalCode"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.postalCode"
 * item[=].item[=].item[=].text = "PLZ"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.city"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.city"
 * item[=].item[=].item[=].text = "Ort"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "receiverCopy.relatedPerson.country"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.country"
 * item[=].item[=].item[=].text = "Land"
 * item[=].item[=].item[=].type = #string
-
-/*------ Appointment ------------------------------ */
 * item[+].linkId = "appointment"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.extension:locationAndTime"
 * item[=].text = "Ort und Zeit der Durchführung der angeforderten Leistung"
 * item[=].type = #group
 * item[=].repeats = true
-
-* item[=].item[+].linkId = "appointment.location"
+* item[=].item[0].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'appointment.location.'"
+* item[=].item[=].linkId = "appointment.location"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.participant.actor"
 * item[=].item[=].text = "Ort der Durchführung"
 * item[=].item[=].type = #group
 * item[=].item[=].required = true
-
-* item[=].item[=].item[+].linkId = "appointment.location.name"
+* item[=].item[=].item[0].linkId = "appointment.location.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.name"
 * item[=].item[=].item[=].text = "Name"
 * item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].required = true
-
 * item[=].item[=].item[+].linkId = "appointment.location.phone"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.telecom.value"
 * item[=].item[=].item[=].text = "Telefon"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "appointment.location.email"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.telecom.value"
 * item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "appointment.location.streetAddressLine"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.line"
 * item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
 * item[=].item[=].item[=].type = #string
 * item[=].item[=].item[=].repeats = true
-
 * item[=].item[=].item[+].linkId = "appointment.location.postalCode"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.postalCode"
 * item[=].item[=].item[=].text = "PLZ"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "appointment.location.city"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.city"
 * item[=].item[=].item[=].text = "Ort"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[=].item[+].linkId = "appointment.location.country"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.country"
 * item[=].item[=].item[=].text = "Land"
 * item[=].item[=].item[=].type = #string
-
 * item[=].item[+].linkId = "appointment.requestedPeriod"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod"
 * item[=].item[=].text = "Datum und Zeit, wann der Termin bevorzugt geplant werden soll"
 * item[=].item[=].type = #group
-
-* item[=].item[=].item[+].linkId = "appointment.requestedPeriod.start"
+* item[=].item[=].item[0].linkId = "appointment.requestedPeriod.start"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod.start"
 * item[=].item[=].item[=].text = "Von"
 * item[=].item[=].item[=].type = #dateTime
-
 * item[=].item[=].item[+].linkId = "appointment.requestedPeriod.end"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod.end"
 * item[=].item[=].item[=].text = "Bis"
 * item[=].item[=].item[=].type = #dateTime
-
 * item[=].item[+].linkId = "appointment.status"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.status"
 * item[=].item[=].text = "Status"
-* item[=].item[=].required = true           // also required in Appointment.status
 * item[=].item[=].type = #choice
-* item[=].item[=].answerOption[+].valueCoding = AppointmentStatus#proposed "Wunsch des Patienten (vorgeschlagen)"
+* item[=].item[=].required = true
+* item[=].item[=].answerOption[0].valueCoding = http://hl7.org/fhir/appointmentstatus#proposed "Wunsch des Patienten (vorgeschlagen)"
 * item[=].item[=].answerOption[=].initialSelected = true
-* item[=].item[=].answerOption[+].valueCoding = AppointmentStatus#pending "Vom Patienten bestätigt, aber vom Leistungserbringer noch nicht (ausstehend)"
-* item[=].item[=].answerOption[+].valueCoding = AppointmentStatus#booked "Vom Patienten und Leistungserbringer bestätigt (gebucht)"
-// * item[=].item[=].answerValueSet = "http://fhir.ch/ig/ch-orf/ValueSet/ch-orf-vs-appointmentstatus"
-
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/appointmentstatus#pending "Vom Patienten bestätigt, aber vom Leistungserbringer noch nicht (ausstehend)"
+* item[=].item[=].answerOption[+].valueCoding = http://hl7.org/fhir/appointmentstatus#booked "Vom Patienten und Leistungserbringer bestätigt (gebucht)"
 * item[=].item[+].linkId = "appointment.patientInstruction"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.patientInstruction"
 * item[=].item[=].text = "Patienteninformation für diesen Termin"
 * item[=].item[=].type = #string
-
-// -------- Service Request Notes ------
 * item[+].linkId = "note"
 * item[=].text = "Bemerkungen"
 * item[=].type = #group
 * item[=].repeats = true
-
-* item[=].item[+].linkId = "note.text"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.note.text"
-* item[=].item[=].text = "Kommentar" 
-* item[=].item[=].type = #string
-* item[=].item[=].required = true
+* item[=].item.linkId = "note.text"
+* item[=].item.definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.note.text"
+* item[=].item.text = "Kommentar"
+* item[=].item.type = #string
+* item[=].item.required = true

--- a/input/fsh/EX_QuestionnaireOrfModule.fsh
+++ b/input/fsh/EX_QuestionnaireOrfModule.fsh
@@ -69,18 +69,6 @@ Description: "Example for Questionnaire"
 * item[=].item.text = "Unable to resolve 'patient' sub-questionnaire"
 * item[=].item.type = #display
 
-// ---------- Patient Contact Person : The principle target of a particular Form Content is one patient ----------
-* item[=].item[+].linkId = "patient.contactperson"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact"
-* item[=].item[=].text = "Kontaktperson"
-* item[=].item[=].type = #group
-
-* item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
-* item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-patientcontact|2.0.0"
-* item[=].item[=].item.linkId = "patientcontact.1"
-* item[=].item[=].item.text = "Unable to resolve 'patientcontact' sub-questionnaire"
-* item[=].item[=].item.type = #display
-
 // ---------- Encounter Class (Ambulant / Satinär / Notfall) ----------
 * item[+].linkId = "requestedEncounter"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.extension:requestedEncounterDetails"
@@ -88,9 +76,9 @@ Description: "Example for Questionnaire"
 * item[=].type = #group
 
 * item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
-* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-requestedEncounter|2.0.0"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-requestedencounter|2.0.0"
 * item[=].item.linkId = "requestedEncounter.1"
-* item[=].item.text = "Unable to resolve 'requestedEncounter' sub-questionnaire"
+* item[=].item.text = "Unable to resolve 'requestedencounter' sub-questionnaire"
 * item[=].item.type = #display
 
 
@@ -134,9 +122,9 @@ Description: "Example for Questionnaire"
 * item[=].type = #group
 
 * item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
-* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receiverCopy|2.0.0"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receivercopy|2.0.0"
 * item[=].item.linkId = "receiverCopy.1"
-* item[=].item.text = "Unable to resolve 'receiverCopy' sub-questionnaire"
+* item[=].item.text = "Unable to resolve 'receivercopy' sub-questionnaire"
 * item[=].item.type = #display
 
 /*------ Appointment ------------------------------ */
@@ -325,7 +313,7 @@ Description: "Subquestionnaire receiver"
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
 * item[=].extension.valueExpression.name = "linkIdPrefix"
 * item[=].extension.valueExpression.language = #text/fhirpath
-* item[=].extension.valueExpression.expression = "'receiverCopy.organization.'"
+* item[=].extension.valueExpression.expression = "'receiver.organization.'"
 
 * item[=].item[+].linkId = "receiver.organization.name"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
@@ -812,11 +800,11 @@ Description: "Subquestionnaire receiverCopy"
 * item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
 * item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
 * item[=].item[=].extension.valueExpression.language = #text/fhirpath
-* item[=].item[=].extension.valueExpression.expression = "'eceiverCopy.practitionerRole.practitione.'"
+* item[=].item[=].extension.valueExpression.expression = "'receiverCopy.practitionerRole.practitioner.'"
 
 * item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
 * item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel|2.0.0"
-* item[=].item[=].item.linkId = "eceiverCopy.practitionerRole.practitione.1"
+* item[=].item[=].item.linkId = "receiverCopy.practitionerRole.practitioner.1"
 * item[=].item[=].item.text = "Unable to resolve 'practitioner-nametel' sub-questionnaire"
 * item[=].item[=].item.type = #display
 

--- a/input/fsh/EX_QuestionnaireOrfModule.fsh
+++ b/input/fsh/EX_QuestionnaireOrfModule.fsh
@@ -322,6 +322,11 @@ Description: "Subquestionnaire receiver"
 * item[=].text = "Empfangende Organisation"
 * item[=].type = #group
 
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].extension.valueExpression.expression = "'receiverCopy.organization.'"
+
 * item[=].item[+].linkId = "receiver.organization.name"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
 * item[=].item[=].text = "Name der Organisation"
@@ -332,26 +337,11 @@ Description: "Subquestionnaire receiver"
 * item[=].item[=].text = "GLN"
 * item[=].item[=].type = #string
 
-* item[=].item[+].linkId = "receiver.organization.streetAddressLine"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.line"
-* item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].item[=].type = #string
-* item[=].item[=].repeats = true
-
-* item[=].item[+].linkId = "receiver.organization.postalCode"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.postalCode"
-* item[=].item[=].text = "PLZ"
-* item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "receiver.organization.city"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.city"
-* item[=].item[=].text = "Ort"
-* item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "receiver.organization.country"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.country"
-* item[=].item[=].text = "Land"
-* item[=].item[=].type = #string
+* item[=].item[+].extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].item[=].linkId = "receiver.organization.1"
+* item[=].item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].item[=].type = #display
 
 
 Instance: ch-orf-module-patient
@@ -366,6 +356,7 @@ Description: "Subquestionnaire patient"
 * status = #active
 * date = "2022-05-04"
 * publisher = "HL7 Switzerland"
+
 
 * item[+].linkId = "patient.familyName"
 * item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.family"
@@ -432,26 +423,15 @@ Description: "Subquestionnaire patient"
 * item[=].text = "E-Mail"
 * item[=].type = #string
 
-* item[+].linkId = "patient.streetAddressLine"
-* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.line"
-* item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].type = #string
-* item[=].repeats = true
-
-* item[+].linkId = "patient.postalCode"
-* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.postalCode"
-* item[=].text = "PLZ"
-* item[=].type = #string
-
-* item[+].linkId = "patient.city"
-* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.city"
-* item[=].text = "Ort"
-* item[=].type = #string
-
-* item[+].linkId = "patient.country"
-* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.country"
-* item[=].text = "Land"
-* item[=].type = #string
+* item[+].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].extension[=].valueExpression.name = "linkIdPrefix"
+* item[=].extension[=].valueExpression.language = #text/fhirpath
+* item[=].extension[=].valueExpression.expression = "'patient.'"
+* item[=].linkId = "patient.1"
+* item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].type = #display
 
 * item[+].linkId = "patient.languageOfCorrespondance"
 * item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.communication:languageOfCorrespondance"
@@ -640,6 +620,10 @@ Description: "Subquestionnaire Converage"
 * item[=].item[=].enableWhen[+].question = "coverage.self.patientRelatedPerson"
 * item[=].item[=].enableWhen[=].operator = #=
 * item[=].item[=].enableWhen[=].answerBoolean = true
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'coverage.self.relatedPerson.'"
 
 * item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.familyName"
 * item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.family"
@@ -662,27 +646,11 @@ Description: "Subquestionnaire Converage"
 * item[=].item[=].item[=].text = "E-Mail"
 * item[=].item[=].item[=].type = #string
 
-* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.streetAddressLine"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.line"
-* item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].item[=].item[=].type = #string
-* item[=].item[=].item[=].repeats = true
-
-* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.postalCode"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.postalCode"
-* item[=].item[=].item[=].text = "PLZ"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.city"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.city"
-* item[=].item[=].item[=].text = "Ort"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.country"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.country"
-* item[=].item[=].item[=].text = "Land"
-* item[=].item[=].item[=].type = #string
-
+* item[=].item[=].item[+].extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item[=].extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].item[=].item[=].linkId = "coverage.self.relatedPerson.1"
+* item[=].item[=].item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].item[=].item[=].type = #display
 
 // Other
 * item[+].linkId = "coverage.other"
@@ -773,6 +741,10 @@ Description: "Subquestionnaire Sender"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
 * item[=].item[=].text = "Verantwortliche Organisation"
 * item[=].item[=].type = #group
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'sender.author.organization.'"
 
 * item[=].item[=].item[+].linkId = "sender.author.organization.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
@@ -784,26 +756,11 @@ Description: "Subquestionnaire Sender"
 * item[=].item[=].item[=].text = "GLN"
 * item[=].item[=].item[=].type = #string
 
-* item[=].item[=].item[+].linkId = "sender.author.organization.streetAddressLine"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.line"
-* item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].item[=].item[=].type = #string
-* item[=].item[=].item[=].repeats = true
-
-* item[=].item[=].item[+].linkId = "sender.author.organization.postalCode"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.postalCode"
-* item[=].item[=].item[=].text = "PLZ"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "sender.author.organization.city"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.city"
-* item[=].item[=].item[=].text = "Ort"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "sender.author.organization.country"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.country"
-* item[=].item[=].item[=].text = "Land"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].item[+].extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item[=].extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].item[=].item[=].linkId = "sender.author.organization.1"
+* item[=].item[=].item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].item[=].item[=].type = #display
 
 // ---------- Data Entry Person: The person who has typed/filled in the Form Content. ----------
 * item[+].linkId = "sender.dataenterer"
@@ -868,32 +825,21 @@ Description: "Subquestionnaire receiverCopy"
 * item[=].item[=].text = "Gesundheitsorganisatiton"
 * item[=].item[=].type = #group
 
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'receiverCopy.practitionerRole.organization.'"
+
 * item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.name"
 * item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
 * item[=].item[=].item[=].text = "Name der Organisation"
 * item[=].item[=].item[=].type = #string
 
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.streetAddressLine"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.line"
-* item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].item[=].item[=].type = #string
-* item[=].item[=].item[=].repeats = true
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.postalCode"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.postalCode"
-* item[=].item[=].item[=].text = "PLZ"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.city"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.city"
-* item[=].item[=].item[=].text = "Ort"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.country"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.country"
-* item[=].item[=].item[=].text = "Land"
-* item[=].item[=].item[=].type = #string
-
+* item[=].item[=].item[+].extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item[=].extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].item[=].item[=].linkId = "receiverCopy.practitionerRole.organization.1"
+* item[=].item[=].item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].item[=].item[=].type = #display
 
 * item[+].linkId = "receiverCopy.patient"
 * item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient"
@@ -911,6 +857,10 @@ Description: "Subquestionnaire receiverCopy"
 * item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.family"
 * item[=].item[=].text = "Name"
 * item[=].item[=].type = #string
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'receiverCopy.relatedPerson.'"
 
 * item[=].item[+].linkId = "receiverCopy.relatedPerson.givenName"
 * item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.given"
@@ -928,26 +878,11 @@ Description: "Subquestionnaire receiverCopy"
 * item[=].item[=].text = "E-Mail"
 * item[=].item[=].type = #string
 
-* item[=].item[+].linkId = "receiverCopy.relatedPerson.streetAddressLine"
-* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.line"
-* item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].item[=].type = #string
-* item[=].item[=].repeats = true
-
-* item[=].item[+].linkId = "receiverCopy.relatedPerson.postalCode"
-* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.postalCode"
-* item[=].item[=].text = "PLZ"
-* item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "receiverCopy.relatedPerson.city"
-* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.city"
-* item[=].item[=].text = "Ort"
-* item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "receiverCopy.relatedPerson.country"
-* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.country"
-* item[=].item[=].text = "Land"
-* item[=].item[=].type = #string
+* item[=].item[+].extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].item[=].linkId = "receiverCopy.relatedPerson.1"
+* item[=].item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].item[=].type = #display
 
 /*------ Appointment ------------------------------ */
 Instance: ch-orf-module-appointment
@@ -968,6 +903,10 @@ Description: "Subquestionnaire appointment"
 * item[=].text = "Ort der Durchführung"
 * item[=].type = #group
 * item[=].required = true
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].extension.valueExpression.expression = "'appointment.location.'"
 
 * item[=].item[+].linkId = "appointment.location.name"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.name"
@@ -985,26 +924,11 @@ Description: "Subquestionnaire appointment"
 * item[=].item[=].text = "E-Mail"
 * item[=].item[=].type = #string
 
-* item[=].item[+].linkId = "appointment.location.streetAddressLine"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.line"
-* item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
-* item[=].item[=].type = #string
-* item[=].item[=].repeats = true
-
-* item[=].item[+].linkId = "appointment.location.postalCode"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.postalCode"
-* item[=].item[=].text = "PLZ"
-* item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "appointment.location.city"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.city"
-* item[=].item[=].text = "Ort"
-* item[=].item[=].type = #string
-
-* item[=].item[+].linkId = "appointment.location.country"
-* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.country"
-* item[=].item[=].text = "Land"
-* item[=].item[=].type = #string
+* item[=].item[+].extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address|2.0.0"
+* item[=].item[=].linkId = "appointment.location.1"
+* item[=].item[=].text = "Unable to resolve 'address' sub-questionnaire"
+* item[=].item[=].type = #display
 
 * item[+].linkId = "appointment.requestedPeriod"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod"
@@ -1076,4 +1000,39 @@ Description: "Subquestionnaire Practitioner with Name/Telecom"
 * item[+].linkId = "email"
 * item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
 * item[=].text = "E-Mail"
+* item[=].type = #string
+
+
+
+/*------ Address ------------------------------ */
+Instance: ch-orf-module-address
+InstanceOf: Questionnaire
+Title: "Module Questionnaire Address"
+Description: "Subquestionnaire Practitioner Address"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* extension[1].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembleContext"
+* extension[=].valueString = "linkIdPrefix"
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-address"
+* name = "ModuleQuestionnaireAddress"
+* title = "Module Questionnaire Address"
+* status = #active
+* date = "2022-05-09"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "streetAddressLine"
+* item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].type = #string
+* item[=].repeats = true
+
+* item[+].linkId = "postalCode"
+* item[=].text = "PLZ"
+* item[=].type = #string
+
+* item[+].linkId = "city"
+* item[=].text = "Ort"
+* item[=].type = #string
+
+* item[+].linkId = "country"
+* item[=].text = "Land"
 * item[=].type = #string

--- a/input/fsh/EX_QuestionnaireOrfModule.fsh
+++ b/input/fsh/EX_QuestionnaireOrfModule.fsh
@@ -1,0 +1,1088 @@
+Instance: order-referral-form-modular
+InstanceOf: ChOrfQuestionnaire
+Title: "Questionnaire Order-Referral-Form"
+Description: "Example for Questionnaire"
+* meta.profile[+] = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-questionnaire"
+* meta.profile[+] = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire"
+* meta.profile[+] = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-extr-smap"
+* meta.profile[+] = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-pop-exp"
+
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-root
+
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-targetStructureMap"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/StructureMap/OrfQrToBundle"
+
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-sourceStructureMap"
+* extension[=].valueCanonical = "http://fhir.ch/ig/ch-orf/StructureMap/OrfPrepopBundleToQr"
+
+* extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext"
+* extension[=].extension[0].url = "name"
+* extension[=].extension[0].valueId = "Bundle"
+* extension[=].extension[1].url = "type"
+* extension[=].extension[1].valueCode = #Bundle
+* extension[=].extension[2].url = "description"
+* extension[=].extension[2].valueString = "The Bundle that is to be used to pre-populate the form"
+
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/order-referral-form-modular"
+* name = "OrderReferralForm"
+* title = "Order-Referral-Form"
+* status = #active
+* subjectType = #Patient
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+// ---------- order (Auftrag) ----------
+* item[+].linkId = "order"
+* item[=].text = "Auftrag"
+* item[=].type = #group
+* item[=].required = true
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-order|2.0.0"
+* item[=].item.linkId = "order.1"
+* item[=].item.text = "Unable to resolve 'order' sub-questionnaire"
+* item[=].item.type = #display
+
+// ---------- Receiver: Person/organization who receives the document ----------
+* item[+].linkId = "receiver"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:receiver"
+* item[=].text = "Empfänger"
+* item[=].type = #group
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receiver|2.0.0"
+* item[=].item.linkId = "receiver.1"
+* item[=].item.text = "Unable to resolve 'receiver' sub-questionnaire"
+* item[=].item.type = #display
+
+// ---------- Patient: The principle target of a particular Form Content is one patient ----------
+* item[+].linkId = "patient"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.subject"
+* item[=].text = "Patient"
+* item[=].type = #group
+* item[=].required = true
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-patient|2.0.0"
+* item[=].item.linkId = "patient.1"
+* item[=].item.text = "Unable to resolve 'patient' sub-questionnaire"
+* item[=].item.type = #display
+
+// ---------- Patient Contact Person : The principle target of a particular Form Content is one patient ----------
+* item[=].item[+].linkId = "patient.contactperson"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact"
+* item[=].item[=].text = "Kontaktperson"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-patientcontact|2.0.0"
+* item[=].item[=].item.linkId = "patientcontact.1"
+* item[=].item[=].item.text = "Unable to resolve 'patientcontact' sub-questionnaire"
+* item[=].item[=].item.type = #display
+
+// ---------- Encounter Class (Ambulant / Satinär / Notfall) ----------
+* item[+].linkId = "requestedEncounter"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.extension:requestedEncounterDetails"
+* item[=].text = "Patientenaufnahme"
+* item[=].type = #group
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-requestedEncounter|2.0.0"
+* item[=].item.linkId = "requestedEncounter.1"
+* item[=].item.text = "Unable to resolve 'requestedEncounter' sub-questionnaire"
+* item[=].item.type = #display
+
+
+// ---------- Coverage (Kostenträger) ----------
+// Design as agreed with eHealth Suisse and Cistec 09.06.2021
+
+* item[+].linkId = "coverage"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.insurance"
+* item[=].text = "Kostenträger"
+* item[=].type = #group
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-coverage|2.0.0"
+* item[=].item.linkId = "coverage.1"
+* item[=].item.text = "Unable to resolve 'coverage' sub-questionnaire"
+* item[=].item.type = #display
+
+// ---------- sender (Absender) ----------
+* item[+].linkId = "sender"
+* item[=].text = "Absender"
+* item[=].type = #group
+* item[=].required = true
+
+// ---------- Author: The person/organization responsible for Form Content ----------
+* item[=].item[+].linkId = "sender.author"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.author"
+* item[=].item[=].text = "Verantwortlicher"
+* item[=].item[=].type = #group
+* item[=].item[=].required = true
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-sender|2.0.0"
+* item[=].item.linkId = "sender.1"
+* item[=].item.text = "Unable to resolve 'sender' sub-questionnaire"
+* item[=].item.type = #display
+
+// ---------- Copy Receiver (Copy of this order and all results therefrom) ----------
+* item[+].linkId = "receiverCopy"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:copyReceiver"
+* item[=].text = "Kopieempfänger (Kopie dieses Auftrags und aller daraus resultierenden Resultate)"
+* item[=].type = #group
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receiverCopy|2.0.0"
+* item[=].item.linkId = "receiverCopy.1"
+* item[=].item.text = "Unable to resolve 'receiverCopy' sub-questionnaire"
+* item[=].item.type = #display
+
+/*------ Appointment ------------------------------ */
+* item[+].linkId = "appointment"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.extension:locationAndTime"
+* item[=].text = "Ort und Zeit der Durchführung der angeforderten Leistung"
+* item[=].type = #group
+* item[=].repeats = true
+
+* item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-appointment|2.0.0"
+* item[=].item.linkId = "appointment.1"
+* item[=].item.text = "Unable to resolve 'appointment' sub-questionnaire"
+* item[=].item.type = #display
+
+// -------- Service Request Notes ------
+* item[+].linkId = "note"
+* item[=].text = "Bemerkungen"
+* item[=].type = #group
+* item[=].repeats = true
+
+* item[=].item[+].linkId = "note.text"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.note.text"
+* item[=].item[=].text = "Kommentar" 
+* item[=].item[=].type = #string
+* item[=].item[=].required = true
+
+Instance: ch-orf-module-order
+InstanceOf: Questionnaire
+Title: "Module Questionnaire order"
+Description: "Subquestionnaire order"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-order"
+* name = "ModuleQuestionnaireOrderForm"
+* title = "Module Questionnaire Order Form"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "order.placerOrderIdentifier"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:placerOrderIdentifier.value"
+* item[=].text = "Auftragsnummer des Auftraggebers"
+* item[=].type = #string
+
+* item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+* item[=].extension.valueBoolean = true
+* item[=].linkId = "order.placerOrderIdentifierDomain"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:placerOrderIdentifier.system"
+* item[=].text = "Identifier Domain der Auftragsnummer des Auftraggebers"
+* item[=].type = #string
+
+* item[+].linkId = "order.fillerOrderIdentifier"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:fillerOrderIdentifier.value"
+* item[=].text = "Auftragsnummer des Auftragsempfängers"
+* item[=].type = #string
+
+* item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+* item[=].extension.valueBoolean = true
+* item[=].linkId = "order.fillerOrderIdentifierDomain"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.identifier:fillerOrderIdentifier.system"
+* item[=].text = "Identifier Domain der Auftragsnummer des Auftragsempfängers"
+* item[=].type = #string
+
+* item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+* item[=].extension.valueBoolean = true
+* item[=].linkId = "order.precedentDocumentIdentifier"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:precedentDocument"
+* item[=].text = "Identifier des Vorgängerdokuments"
+* item[=].type = #string
+
+// ---------- Urgent Notification Contact for this document ----------
+* item[+].linkId = "order.notificationContactDocument"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:urgentNoficationContactForThisDocument"
+* item[=].text = "Dringender Benachrichtigungskontakt für dieses Dokument"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "order.notificationContactDocument.practitioner"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].text = "Zu benachrichtigende Person"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.title"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].item[=].text = "Titel"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.familyName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item[=].text = "Name"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.givenName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item[=].text = "Vorname"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.phone"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "Telefon"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.email"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "E-Mail"
+* item[=].item[=].item[=].type = #string
+
+// ---------- Urgent Notification Contact for the Response to this document ----------
+* item[+].linkId = "order.notificationContactDocumentResponse"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:urgentNoficationContactForTheResponseToThisDocument"
+* item[=].text = "Dringender Benachrichtigungskontakt für die Antwort auf dieses Dokument"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].text = "Zu benachrichtigende Person"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.title"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].item[=].text = "Titel"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.familyName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item[=].text = "Name"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.givenName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item[=].text = "Vorname"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.phone"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "Telefon"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.email"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "E-Mail"
+* item[=].item[=].item[=].type = #string
+
+// ---------- Order Priority ----------
+* item[+].linkId = "order.priority"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-servicerequest#ServiceRequest.priority"
+* item[=].text = "Auftragspriorität"
+* item[=].type = #choice
+* item[=].answerOption[+].valueCoding = RequestPriority#routine "Die Anfrage hat normale Priorität."
+* item[=].answerOption[=].initialSelected = true
+* item[=].answerOption[+].valueCoding = RequestPriority#urgent "Die Anfrage sollte dringend bearbeitet werden - höhere Priorität als normal."
+* item[=].answerOption[+].valueCoding = RequestPriority#asap "Die Anfrage sollte so schnell wie möglich bearbeitet werden - höhere Priorität als dringend."
+* item[=].answerOption[+].valueCoding = RequestPriority#stat "Die Anfrage sollte sofort bearbeitet werden - höchstmögliche Priorität. Z.B. bei einem Notfall."
+
+Instance: ch-orf-module-receiver
+InstanceOf: Questionnaire
+Title: "Module Questionnaire receiver"
+Description: "Subquestionnaire receiver"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receiver"
+* name = "ModuleQuestionnaireOrderReceiver"
+* title = "Module Questionnaire Order Receiver"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "receiver.practitioner"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].text = "Empfangende Person"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "receiver.practitioner.title"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].text = "Titel"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.practitioner.familyName"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].text = "Name"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.practitioner.givenName"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].text = "Vorname"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.practitioner.gln"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:GLN.value"
+* item[=].item[=].text = "GLN"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.practitioner.zsr"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:ZSR.value"
+* item[=].item[=].text = "ZSR"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.practitioner.phone"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].text = "Telefon"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.practitioner.email"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].text = "E-Mail"
+* item[=].item[=].type = #string
+
+* item[+].linkId = "receiver.organization"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
+* item[=].text = "Empfangende Organisation"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "receiver.organization.name"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
+* item[=].item[=].text = "Name der Organisation"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.organization.gln"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.identifier:GLN"
+* item[=].item[=].text = "GLN"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.organization.streetAddressLine"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.line"
+* item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].item[=].type = #string
+* item[=].item[=].repeats = true
+
+* item[=].item[+].linkId = "receiver.organization.postalCode"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.postalCode"
+* item[=].item[=].text = "PLZ"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.organization.city"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.city"
+* item[=].item[=].text = "Ort"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiver.organization.country"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.country"
+* item[=].item[=].text = "Land"
+* item[=].item[=].type = #string
+
+
+Instance: ch-orf-module-patient
+InstanceOf: Questionnaire
+Title: "Module Questionnaire patient"
+Description: "Subquestionnaire patient"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-patient"
+* name = "ModuleQuestionnaireOrderPatient"
+* title = "Module Questionnaire Order Patient"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "patient.familyName"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.family"
+* item[=].text = "Name"
+* item[=].type = #string
+
+* item[+].linkId = "patient.maidenName"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.family"
+* item[=].text = "Ledigname"
+* item[=].type = #string
+
+* item[+].linkId = "patient.givenName"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.name.given"
+* item[=].text = "Vorname"
+* item[=].type = #string
+
+* item[+].linkId = "patient.localPid"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:LocalPid.value"
+* item[=].text = "Lokale Patienten-ID"
+* item[=].type = #string
+
+* item[+].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden"
+* item[=].extension.valueBoolean = true
+* item[=].linkId = "patient.localPidDomain"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:LocalPid.system"
+* item[=].text = "Lokale Patienten-ID Domain"
+* item[=].type = #string
+
+* item[+].linkId = "patient.birthDate"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.birthDate"
+* item[=].text = "Geburtsdatum"
+* item[=].type = #date
+
+* item[+].linkId = "patient.gender"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.gender"
+* item[=].text = "Geschlecht"
+* item[=].type = #choice
+* item[=].answerOption[+].valueCoding = AdministrativeGender#male "Männlich"
+* item[=].answerOption[=].initialSelected = true
+* item[=].answerOption[+].valueCoding = AdministrativeGender#female "Weiblich"
+* item[=].answerOption[+].valueCoding = AdministrativeGender#other "Anderes"
+
+* item[+].linkId = "patient.maritalStatus"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.maritalStatus"
+* item[=].text = "Zivilstand"
+* item[=].type = #choice
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#1 "ledig"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#2 "verheiratet"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#3 "verwitwet"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#4 "geschieden"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#5 "unverheiratet"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#6 "in eingetragener Partnerschaft"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#7 "aufgelöste Partnerschaft"
+* item[=].answerOption[+].valueCoding = EchMaritalStatus#9 "unbekannt"
+
+* item[+].linkId = "patient.phone"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.telecom.value"
+* item[=].text = "Telefon"
+* item[=].type = #string
+* item[=].repeats = true
+
+* item[+].linkId = "patient.email"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.telecom.value"
+* item[=].text = "E-Mail"
+* item[=].type = #string
+
+* item[+].linkId = "patient.streetAddressLine"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.line"
+* item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].type = #string
+* item[=].repeats = true
+
+* item[+].linkId = "patient.postalCode"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.postalCode"
+* item[=].text = "PLZ"
+* item[=].type = #string
+
+* item[+].linkId = "patient.city"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.city"
+* item[=].text = "Ort"
+* item[=].type = #string
+
+* item[+].linkId = "patient.country"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.address.country"
+* item[=].text = "Land"
+* item[=].type = #string
+
+* item[+].linkId = "patient.languageOfCorrespondance"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.communication:languageOfCorrespondance"
+* item[=].text = "Korrespondenssprache"
+* item[=].type = #choice
+* item[=].answerValueSet = "http://fhir.ch/ig/ch-epr-term/ValueSet/DocumentEntry.languageCode"
+
+// ---------- Patient Contact Person : The principle target of a particular Form Content is one patient ----------
+* item[+].linkId = "patient.contactperson"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact"
+* item[=].text = "Kontaktperson"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "patient.contactperson.relationship"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.relationship.text"
+* item[=].item[=].text = "Beziehung"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "patient.contactperson.familyName"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.name.family"
+* item[=].item[=].text = "Name"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "patient.contactperson.givenName"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.name.given"
+* item[=].item[=].text = "Vorname"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "patient.contactperson.phone"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.telecom.value"
+* item[=].item[=].text = "Telefon"
+* item[=].item[=].type = #string
+* item[=].item[=].repeats = true
+
+* item[=].item[+].linkId = "patient.contactperson.email"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.contact.telecom.value"
+* item[=].item[=].text = "E-Mail"
+* item[=].item[=].type = #string
+
+Instance: ch-orf-module-requestedencounter
+InstanceOf: Questionnaire
+Title: "Module Questionnaire requestedEncounter"
+Description: "Subquestionnaire patrequestedEncounterient"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-requestedencounter"
+* name = "ModuleQuestionnaireOrderRequestedEncounter"
+* title = "Module Questionnaire Order requestedEncounter"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "requestedEncounter.class"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-encounter#Encounter.class"
+* item[=].type = #choice
+* item[=].text = "Voraussichtlich: Ambulant / Stationär / Notfall"
+* item[=].answerOption[+].valueCoding = V3ActCode#AMB "Ambulant"
+* item[=].answerOption[+].valueCoding = V3ActCode#IMP "Stationär"
+* item[=].answerOption[+].valueCoding = V3ActCode#EMER "Notfall"
+
+* item[+].linkId = "requestedEncounter.desiredAccommodation"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-encounter#Encounter.extension:desiredAccommodation"
+* item[=].text = "Zimmerkategorie"
+* item[=].type = #choice
+* item[=].answerOption[+].valueCoding = ChCoreCSEncounterType#1 "allgemein"
+* item[=].answerOption[+].valueCoding = ChCoreCSEncounterType#2 "halbprivat"
+* item[=].answerOption[+].valueCoding = ChCoreCSEncounterType#3 "privat"
+
+
+Instance: ch-orf-module-coverage
+InstanceOf: Questionnaire
+Title: "Module Questionnaire Coverage"
+Description: "Subquestionnaire Converage"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-coverage"
+* name = "ModuleQuestionnaireOrderCoverage"
+* title = "Module Questionnaire Order Coverage"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "coverage.beneficiary"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.beneficiary"
+* item[=].text = "Begünstigter (Patient)"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.beneficiary.ahvn13"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient.identifier:AHVN13"
+* item[=].item[=].text = "AHV-Nr. des Patienten"
+* item[=].item[=].type = #string
+
+// KVG
+* item[+].linkId = "coverage.kvg"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Krankenkasse (nach KVG)"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.kvg.name"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Name der Versicherung"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "coverage.kvg.insuranceCardNumber"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].text = "Kennnummer der Versichertenkarte"
+* item[=].item[=].type = #string
+
+// UVG
+* item[+].linkId = "coverage.uvg"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Unfallversicherung (nach UVG)"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.uvg.name"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Name der Versicherung"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "coverage.uvg.claimNumber"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].text = "Schadennummer"
+* item[=].item[=].type = #string
+
+// Zusatz
+* item[+].linkId = "coverage.vvg"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Zusatzversicherung (nach VVG)"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.vvg.name"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Name der Versicherung"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "coverage.vvg.insuranceCardNumber"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].text = "Kennnummer der Versichertenkarte"
+* item[=].item[=].type = #string
+
+// IV
+* item[+].linkId = "coverage.iv"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Invalidenversicherung (IV)"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.iv.verfuegungsnummer"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].text = "IV-Verfügungsnummer"
+* item[=].item[=].type = #string
+
+// MV
+* item[+].linkId = "coverage.mv"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Militärversicherung (MV)"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.mv.versichertennummer"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].text = "MV-Versichertennummer"
+* item[=].item[=].type = #string
+
+// Self
+* item[+].linkId = "coverage.self"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Selbstzahler"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.self.patient"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Patient selbst"
+* item[=].item[=].type = #boolean
+
+* item[=].item[+].linkId = "coverage.self.patientRelatedPerson"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Andere Person"
+* item[=].item[=].type = #boolean
+* item[=].item[=].enableWhen[+].question = "coverage.self.patient"
+* item[=].item[=].enableWhen[=].operator = #=
+* item[=].item[=].enableWhen[=].answerBoolean = false
+
+* item[=].item[+].linkId = "coverage.self.relatedPerson" 
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Andere Person"   
+* item[=].item[=].type = #group
+* item[=].item[=].enableWhen[+].question = "coverage.self.patientRelatedPerson"
+* item[=].item[=].enableWhen[=].operator = #=
+* item[=].item[=].enableWhen[=].answerBoolean = true
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.familyName"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.family"
+* item[=].item[=].item[=].text = "Name"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.givenName"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.given"
+* item[=].item[=].item[=].text = "Vorname"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.phone"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
+* item[=].item[=].item[=].text = "Telefon"
+* item[=].item[=].item[=].type = #string
+* item[=].item[=].item[=].repeats = true
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.email"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
+* item[=].item[=].item[=].text = "E-Mail"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.streetAddressLine"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.line"
+* item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].item[=].item[=].type = #string
+* item[=].item[=].item[=].repeats = true
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.postalCode"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.postalCode"
+* item[=].item[=].item[=].text = "PLZ"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.city"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.city"
+* item[=].item[=].item[=].text = "Ort"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "coverage.self.relatedPerson.country"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.country"
+* item[=].item[=].item[=].text = "Land"
+* item[=].item[=].item[=].type = #string
+
+
+// Other
+* item[+].linkId = "coverage.other"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.type"
+* item[=].text = "Anderer Kostenträger"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "coverage.other.name"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.payor"
+* item[=].item[=].text = "Name des Kostenträgers"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "coverage.other.id"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier"
+* item[=].item[=].text = "Beliebige ID"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "coverage.other.id.note"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-coverage#Coverage.identifier.type.text"
+* item[=].item[=].text = "Bemerkung zur ID"
+* item[=].item[=].type = #string
+
+// The situation where a person and not a organization is an other payer is not depicted. 
+// Id's of insurances other than kvg are proprietary. Zusatzversicherung however may use the Kennnummer der Versichertenkarte (KVG).
+// Id's for other are not defined.
+
+Instance: ch-orf-module-sender
+InstanceOf: Questionnaire
+Title: "Module Questionnaire Sender"
+Description: "Subquestionnaire Sender"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-sender"
+* name = "ModuleQuestionnaireOrderSender"
+* title = "Module Questionnaire Order Sender"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+// ---------- Author: The person/organization responsible for Form Content ----------
+* item[+].linkId = "sender.author"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.author"
+* item[=].text = "Verantwortlicher"
+* item[=].type = #group
+* item[=].required = true
+
+* item[=].item[+].linkId = "sender.author.practitioner"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].text = "Verantwortliche Person"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.title"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].item[=].item[=].text = "Titel"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.familyName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item[=].text = "Name"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.givenName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item[=].text = "Vorname"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.gln"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:GLN.value"
+* item[=].item[=].item[=].text = "GLN"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.zsr"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.identifier:ZSR.value"
+* item[=].item[=].item[=].text = "ZSR"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.phone"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "Telefon"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.practitioner.email"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "E-Mail"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "sender.author.organization"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
+* item[=].item[=].text = "Verantwortliche Organisation"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "sender.author.organization.name"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
+* item[=].item[=].item[=].text = "Name der Organisation"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.organization.gln"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.identifier:GLN"
+* item[=].item[=].item[=].text = "GLN"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.organization.streetAddressLine"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.line"
+* item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].item[=].item[=].type = #string
+* item[=].item[=].item[=].repeats = true
+
+* item[=].item[=].item[+].linkId = "sender.author.organization.postalCode"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.postalCode"
+* item[=].item[=].item[=].text = "PLZ"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.organization.city"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.city"
+* item[=].item[=].item[=].text = "Ort"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.author.organization.country"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.address.country"
+* item[=].item[=].item[=].text = "Land"
+* item[=].item[=].item[=].type = #string
+
+// ---------- Data Entry Person: The person who has typed/filled in the Form Content. ----------
+* item[+].linkId = "sender.dataenterer"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-composition#Composition.extension:dataEnterer"
+* item[=].text = "Erfasser"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "sender.dataenterer.practitioner"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].text = "Erfassende Person"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.familyName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].item[=].item[=].text = "Name"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.givenName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].item[=].item[=].text = "Vorname"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.phone"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "Telefon"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.email"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].item[=].item[=].text = "E-Mail"
+* item[=].item[=].item[=].type = #string
+
+
+Instance: ch-orf-module-receivercopy
+InstanceOf: Questionnaire
+Title: "Module Questionnaire receiverCopy"
+Description: "Subquestionnaire receiverCopy"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-receivercopy"
+* name = "ModuleQuestionnaireOrderReceiverCopy"
+* title = "Module Questionnaire Order receiverCopy"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "receiverCopy.practitionerRole"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole"
+* item[=].text = "Gesundheitsfachperson oder -organisation"
+* item[=].type = #group
+* item[=].repeats = true
+
+* item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.practitioner"
+* item[=].item[=].text = "Gesundheitsfachperson"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.title"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.prefix"
+* item[=].item[=].item[=].text = "Titel"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.familyName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.family"
+* item[=].item[=].item[=].text = "Name"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.givenName"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.given"
+* item[=].item[=].item[=].text = "Vorname"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.phone"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/ContactPoint#ContactPoint.value"
+* item[=].item[=].item[=].text = "Telefon"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.email"
+* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/ContactPoint#ContactPoint.value"
+* item[=].item[=].item[=].text = "E-Mail"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiverCopy.practitionerRole.organization"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
+* item[=].item[=].text = "Gesundheitsorganisatiton"
+* item[=].item[=].type = #group
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.name"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-organization#Organization.name"
+* item[=].item[=].item[=].text = "Name der Organisation"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.streetAddressLine"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.line"
+* item[=].item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].item[=].item[=].type = #string
+* item[=].item[=].item[=].repeats = true
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.postalCode"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.postalCode"
+* item[=].item[=].item[=].text = "PLZ"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.city"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.city"
+* item[=].item[=].item[=].text = "Ort"
+* item[=].item[=].item[=].type = #string
+
+* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.organization.country"
+* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-address#Address.country"
+* item[=].item[=].item[=].text = "Land"
+* item[=].item[=].item[=].type = #string
+
+
+* item[+].linkId = "receiverCopy.patient"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient#Patient"
+* item[=].text = "Patient selbst"
+* item[=].type = #boolean
+
+
+* item[+].linkId = "receiverCopy.relatedPerson"
+* item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson"
+* item[=].text = "Andere Person"
+* item[=].type = #group
+* item[=].repeats = true
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.familyName"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.family"
+* item[=].item[=].text = "Name"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.givenName"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.name.given"
+* item[=].item[=].text = "Vorame"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.phone"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
+* item[=].item[=].text = "Telefon"
+* item[=].item[=].type = #string
+* item[=].item[=].repeats = true
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.email"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.telecom.value"
+* item[=].item[=].text = "E-Mail"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.streetAddressLine"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.line"
+* item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].item[=].type = #string
+* item[=].item[=].repeats = true
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.postalCode"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.postalCode"
+* item[=].item[=].text = "PLZ"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.city"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.city"
+* item[=].item[=].text = "Ort"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "receiverCopy.relatedPerson.country"
+* item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/RelatedPerson#RelatedPerson.address.country"
+* item[=].item[=].text = "Land"
+* item[=].item[=].type = #string
+
+/*------ Appointment ------------------------------ */
+Instance: ch-orf-module-appointment
+InstanceOf: Questionnaire
+Title: "Module Questionnaire Appointment"
+Description: "Subquestionnaire appointment"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-appointment"
+* name = "ModuleQuestionnaireOrderAppointment"
+* title = "Module Questionnaire Order Appointment"
+* status = #active
+* date = "2022-05-04"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "appointment.location"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.participant.actor"
+* item[=].text = "Ort der Durchführung"
+* item[=].type = #group
+* item[=].required = true
+
+* item[=].item[+].linkId = "appointment.location.name"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.name"
+* item[=].item[=].text = "Name"
+* item[=].item[=].type = #string
+* item[=].item[=].required = true
+
+* item[=].item[+].linkId = "appointment.location.phone"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.telecom.value"
+* item[=].item[=].text = "Telefon"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "appointment.location.email"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.telecom.value"
+* item[=].item[=].text = "E-Mail"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "appointment.location.streetAddressLine"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.line"
+* item[=].item[=].text = "Strasse, Hausnummer, Postfach etc."
+* item[=].item[=].type = #string
+* item[=].item[=].repeats = true
+
+* item[=].item[+].linkId = "appointment.location.postalCode"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.postalCode"
+* item[=].item[=].text = "PLZ"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "appointment.location.city"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.city"
+* item[=].item[=].text = "Ort"
+* item[=].item[=].type = #string
+
+* item[=].item[+].linkId = "appointment.location.country"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-location#Location.address.country"
+* item[=].item[=].text = "Land"
+* item[=].item[=].type = #string
+
+* item[+].linkId = "appointment.requestedPeriod"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod"
+* item[=].text = "Datum und Zeit, wann der Termin bevorzugt geplant werden soll"
+* item[=].type = #group
+
+* item[=].item[+].linkId = "appointment.requestedPeriod.start"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod.start"
+* item[=].item[=].text = "Von"
+* item[=].item[=].type = #dateTime
+
+* item[=].item[+].linkId = "appointment.requestedPeriod.end"
+* item[=].item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.requestedPeriod.end"
+* item[=].item[=].text = "Bis"
+* item[=].item[=].type = #dateTime
+
+* item[+].linkId = "appointment.status"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.status"
+* item[=].text = "Status"
+* item[=].required = true           // also required in Appointment.status
+* item[=].type = #choice
+* item[=].answerOption[+].valueCoding = AppointmentStatus#proposed "Wunsch des Patienten (vorgeschlagen)"
+* item[=].answerOption[=].initialSelected = true
+* item[=].answerOption[+].valueCoding = AppointmentStatus#pending "Vom Patienten bestätigt, aber vom Leistungserbringer noch nicht (ausstehend)"
+* item[=].answerOption[+].valueCoding = AppointmentStatus#booked "Vom Patienten und Leistungserbringer bestätigt (gebucht)"
+// * item[=].answerValueSet = "http://fhir.ch/ig/ch-orf/ValueSet/ch-orf-vs-appointmentstatus"
+
+* item[+].linkId = "appointment.patientInstruction"
+* item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.patientInstruction"
+* item[=].text = "Patienteninformation für diesen Termin"
+* item[=].type = #string

--- a/input/fsh/EX_QuestionnaireOrfModule.fsh
+++ b/input/fsh/EX_QuestionnaireOrfModule.fsh
@@ -219,30 +219,17 @@ Description: "Subquestionnaire order"
 * item[=].item[=].text = "Zu benachrichtigende Person"
 * item[=].item[=].type = #group
 
-* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.title"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
-* item[=].item[=].item[=].text = "Titel"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'order.notificationContactDocument.practitioner.'"
 
-* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.familyName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
-* item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel|2.0.0"
+* item[=].item[=].item.linkId = "order.notificationContactDocument.practitioner.1"
+* item[=].item[=].item.text = "Unable to resolve 'practitioner-nametel' sub-questionnaire"
+* item[=].item[=].item.type = #display
 
-* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.givenName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
-* item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.phone"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocument.practitioner.email"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].type = #string
 
 // ---------- Urgent Notification Contact for the Response to this document ----------
 * item[+].linkId = "order.notificationContactDocumentResponse"
@@ -255,30 +242,16 @@ Description: "Subquestionnaire order"
 * item[=].item[=].text = "Zu benachrichtigende Person"
 * item[=].item[=].type = #group
 
-* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.title"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
-* item[=].item[=].item[=].text = "Titel"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'order.notificationContactDocumentResponse.practitioner.'"
 
-* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.familyName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
-* item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.givenName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
-* item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.phone"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "order.notificationContactDocumentResponse.practitioner.email"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel|2.0.0"
+* item[=].item[=].item.linkId = "order.notificationContactDocumentResponse.practitioner.1"
+* item[=].item[=].item.text = "Unable to resolve 'practitioner-nametel' sub-questionnaire"
+* item[=].item[=].item.type = #display
 
 // ---------- Order Priority ----------
 * item[+].linkId = "order.priority"
@@ -843,26 +816,17 @@ Description: "Subquestionnaire Sender"
 * item[=].item[=].text = "Erfassende Person"
 * item[=].item[=].type = #group
 
-* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.familyName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
-* item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].type = #string
 
-* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.givenName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
-* item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'sender.dataenterer.practitioner.'"
 
-* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.phone"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "sender.dataenterer.practitioner.email"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
-* item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].type = #string
-
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel|2.0.0"
+* item[=].item[=].item.linkId = "sender.dataenterer.practitioner.1"
+* item[=].item[=].item.text = "Unable to resolve 'practitioner-nametel' sub-questionnaire"
+* item[=].item[=].item.type = #display
 
 Instance: ch-orf-module-receivercopy
 InstanceOf: Questionnaire
@@ -888,30 +852,16 @@ Description: "Subquestionnaire receiverCopy"
 * item[=].item[=].text = "Gesundheitsfachperson"
 * item[=].item[=].type = #group
 
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.title"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.prefix"
-* item[=].item[=].item[=].text = "Titel"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/variable"
+* item[=].item[=].extension.valueExpression.name = "linkIdPrefix"
+* item[=].item[=].extension.valueExpression.language = #text/fhirpath
+* item[=].item[=].extension.valueExpression.expression = "'eceiverCopy.practitionerRole.practitione.'"
 
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.familyName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.family"
-* item[=].item[=].item[=].text = "Name"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.givenName"
-* item[=].item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-humanname#HumanName.given"
-* item[=].item[=].item[=].text = "Vorname"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.phone"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/ContactPoint#ContactPoint.value"
-* item[=].item[=].item[=].text = "Telefon"
-* item[=].item[=].item[=].type = #string
-
-* item[=].item[=].item[+].linkId = "receiverCopy.practitionerRole.practitioner.email"
-* item[=].item[=].item[=].definition = "http://hl7.org/fhir/StructureDefinition/ContactPoint#ContactPoint.value"
-* item[=].item[=].item[=].text = "E-Mail"
-* item[=].item[=].item[=].type = #string
+* item[=].item[=].item.extension.url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire"
+* item[=].item[=].item.extension.valueCanonical = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel|2.0.0"
+* item[=].item[=].item.linkId = "eceiverCopy.practitionerRole.practitione.1"
+* item[=].item[=].item.text = "Unable to resolve 'practitioner-nametel' sub-questionnaire"
+* item[=].item[=].item.type = #display
 
 * item[=].item[+].linkId = "receiverCopy.practitionerRole.organization"
 * item[=].item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitionerrole#PractitionerRole.organization"
@@ -1085,4 +1035,45 @@ Description: "Subquestionnaire appointment"
 * item[+].linkId = "appointment.patientInstruction"
 * item[=].definition = "http://fhir.ch/ig/ch-orf/StructureDefinition/ch-orf-appointment#Appointment.patientInstruction"
 * item[=].text = "Patienteninformation für diesen Termin"
+* item[=].type = #string
+
+/*------ Practitioner Name / Telecom ------------------------------ */
+Instance: ch-orf-module-practitioner-nametel
+InstanceOf: Questionnaire
+Title: "Module Questionnaire Practitioner with Name/Telecom"
+Description: "Subquestionnaire Practitioner with Name/Telecom"
+* extension[0].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assemble-expectation"
+* extension[=].valueCode = #assemble-child
+* extension[1].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembleContext"
+* extension[=].valueString = "linkIdPrefix"
+* url = "http://fhir.ch/ig/ch-orf/Questionnaire/ch-orf-module-practitioner-nametel"
+* name = "ModuleQuestionnairePractitionerNameTel"
+* title = "Module Questionnaire Practitioner with name and telecom"
+* status = #active
+* date = "2022-05-09"
+* publisher = "HL7 Switzerland"
+
+* item[+].linkId = "title"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.prefix"
+* item[=].text = "Titel"
+* item[=].type = #string
+
+* item[+].linkId = "familyName"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.family"
+* item[=].text = "Name"
+* item[=].type = #string
+
+* item[+].linkId = "givenName"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.name.given"
+* item[=].text = "Vorname"
+* item[=].type = #string
+
+* item[+].linkId = "phone"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].text = "Telefon"
+* item[=].type = #string
+
+* item[+].linkId = "email"
+* item[=].definition = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-practitioner#Practitioner.telecom.value"
+* item[=].text = "E-Mail"
 * item[=].type = #string


### PR DESCRIPTION
With SDC 3.0 [modular forms](https://hl7.org/fhir/uv/sdc/modular.html) were introduced. This allows to split the questionnaire in subQuestionnaires and let the finalized questionnaire be assembled either during questionnaire generation or by the form filler.

With this PR the ORF questionnaire is split in subQuestionnaires for the main part and additionally a few repeating questionnaires (e.g. address) have been refactored. This allows now the derived questionnaires also to include this subQuestionnaires and there will be no more need to copy past the base ORF questionnaire into the derived questionnaires.

FHIR defines a [$assemble](http://hl7.org/fhir/uv/sdc/OperationDefinition-Questionnaire-assemble.html) operation, however there is no support till now and the assemble process is not yet integrated in [IG Publisher](https://chat.fhir.org/#narrow/stream/179255-questionnaire/topic/Modular.20questionnaire.20assemble.20support.20in.20IG.20Publisher). A prototype for a first version is drafted [here](https://github.com/ahdis/matchbox/issues/46).

In this PR the ORF questionnaire.fsh is the assembled questionnaire generated and converted back to fsh for comparison.
